### PR TITLE
ci: implement workflows for partial release automation

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,17 +1,12 @@
-name: build-android
+name: "Build Android APK"
 
 on:
-  push:
-    branches:
-      - main
-      - develop
   workflow_dispatch: { }
+  workflow_call:
 
 jobs:
-  Android:
+  build-android:
     runs-on: ubuntu-latest
-    env:
-      ANDROID_LOCATION: build/android/build-android-${{ github.sha }}.apk
     steps:
       - name: Setup repo
         uses: actions/checkout@v2
@@ -41,15 +36,21 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
+      - name: Get current package version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+
+      - run: echo OUTPUT_LOCATION=build/android/KopfsachenRNA-${{ steps.extract_version.outputs.version }}.apk | tee "$GITHUB_ENV"
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build Android
-        run: eas build -p android --profile=preview --local --non-interactive --output=${{env.ANDROID_LOCATION}}
+        run: eas build -p android --profile=preview --local --non-interactive --output=${{env.OUTPUT_LOCATION}}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         if: success()
         with:
           name: android
-          path: ${{env.ANDROID_LOCATION}}
+          path: ${{ env.OUTPUT_LOCATION }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,17 +1,12 @@
-name: build-ios
+name: "Build iOS App"
 
 on:
-  push:
-    branches:
-      - main
-      - develop
   workflow_dispatch: { }
+  workflow_call:
 
 jobs:
-  IOS:
+  build-ios:
     runs-on: macos-latest
-    env:
-      IOS_LOCATION: build/ios/build-ios-${{ github.sha }}.tar.gz
     steps:
       - name: Setup repo
         uses: actions/checkout@v2
@@ -30,15 +25,21 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
           packager: npm
 
+      - name: Get current package version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+
+      - run: echo OUTPUT_LOCATION=build/ios/KopfsachenRNA-${{ steps.extract_version.outputs.version }}.tar.gz | tee "$GITHUB_ENV"
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build ios
-        run: eas build -p ios --profile=preview --local --non-interactive --output=${{env.IOS_LOCATION}}
+        run: eas build -p ios --profile=preview --local --non-interactive --output=${{env.OUTPUT_LOCATION}}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         if: success()
         with:
           name: ios
-          path: ${{env.IOS_LOCATION}}
+          path: ${{ env.OUTPUT_LOCATION }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,95 @@
+name: "CI/CD"
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - release/*
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: "Publish on expo.dev"
+    uses: ./.github/workflows/publish.yml
+
+  build-android:
+    name: "Build Android APK"
+    uses: ./.github/workflows/build-android.yml
+
+  build-ios:
+    name: "Build iOS App"
+    uses: ./.github/workflows/build-ios.yml
+
+  check-release-version:
+    name: "Check release version"
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+        with:
+          # actions/checkout does a shallow clone by default, which doesn't pull any tags
+          fetch-depth: 0
+
+      - name: Get current package version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+
+      - name: Check that package version and release version match
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          ref_version="${GITHUB_REF#refs/heads/release/}"
+          if [[ "$ref_version" != "${{ steps.extract_version.outputs.version }}" ]]; then
+            echo "::error title=Version Mismatch::Version '$ref_version' from branch name does not match package version '${{ steps.extract_version.outputs.version }}'. Did you bump the package version?"
+            exit 1
+          fi
+
+      - name: Check that no tag for the current version already exists
+        run: |
+          git tag -l
+          if git tag -l | grep -Fxq "v${{ steps.extract_version.outputs.version }}"; then
+            echo "::error title=v${{ steps.extract_version.outputs.version }} already exists::The release tag 'v${{ steps.extract_version.outputs.version }}' already exists."
+            exit 1
+          fi
+
+  release:
+    name: "Release"
+    if: github.ref == 'refs/heads/main'
+    needs: [ publish, build-android, build-ios, check-release-version ]
+    runs-on: ubuntu-latest
+    # Prevent multiple release jobs running at once
+    concurrency: release
+    permissions:
+      # Needed to push tags
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: fregante/setup-git-user@v1
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
+
+      - name: Create tag
+        run: |
+          git tag -a "v${{ steps.extract_version.outputs.version }}" -m "Release ${{ steps.extract_version.outputs.version }}"
+          git push --tags
+
+      - name: Create release
+        id: release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.extract_version.outputs.version }}
+          files: artifacts/**
+
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+      - name: Generate job summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOT
+          ### [KopfsachenRNA ${{ steps.extract_version.outputs.version }}](${{ steps.release.outputs.url }}) has been released :rocket:
+          EOT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,14 @@
-name: publish
+name: "Publish on expo.dev"
 
 on:
-  push:
-    branches:
-      - main
-      - develop
+  workflow_dispatch:
+  workflow_call:
   pull_request:
     branches:
       - '*'
 
 jobs:
-  Publish:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
@@ -35,13 +33,27 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Set release channel to PR number
-        if: ${{ github.event_name == 'pull_request' }}
-        run: echo "release_channel=pr-${{ github.event.number }}" >> $GITHUB_ENV
-
-      - name: Set release channel to branch name
-        if: ${{ github.event_name == 'push' }}
-        run: echo "release_channel=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Set release channel
+        run: |
+          case "$GITHUB_REF" in
+            refs/pull/*/merge)
+              release_channel="pr-${{ github.event.number }}"
+              ;;
+            refs/heads/main|refs/heads/develop)
+              release_channel="${GITHUB_REF#refs/heads/}"
+              ;;
+            refs/heads/release/*)
+              release_channel="rc-${GITHUB_REF#refs/heads/release/}"
+              ;;
+            refs/heads/**)
+              release_channel="${GITHUB_REF#refs/heads/}"
+              ;;
+            *)
+              echo "::error title='Unsupported ref'::Can't infer expo release channel since ref '$GITHUB_REF' is neither a branch nor a PR."
+              exit 1
+              ;;
+          esac
+          echo "release_channel=$release_channel" | tee "$GITHUB_ENV"
 
       - name: Publish app
         run: expo publish --release-channel=${{ env.release_channel }} --non-interactive

--- a/.github/workflows/release-finish.yml
+++ b/.github/workflows/release-finish.yml
@@ -1,0 +1,84 @@
+name: "Finish a release"
+
+concurrency: release
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          if [[ "$GITHUB_REF" != refs/heads/release/* ]]; then
+            echo "::error title=Not a release branch::Refusing to merge non-release ref $GITHUB_REF into main"
+            exit 1
+          fi
+
+  merge-into-main:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout develop
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Setup git name
+        run: |
+          git config --local user.name "kopfsachen-rna-bot"
+          git config --local user.email "<>"
+
+      - name: Merge into main
+        run: git pull --no-ff origin ${GITHUB_REF#refs/heads/}
+
+      - name: Push
+        run: git push
+
+  merge-into-develop:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout develop
+        uses: actions/checkout@v2
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Setup git name
+        run: |
+          git config --local user.name "kopfsachen-rna-bot"
+          git config --local user.email "<>"
+
+      - name: Merge into main
+        run: git pull --no-ff origin ${GITHUB_REF#refs/heads/}
+
+      - name: Push
+        run: git push
+
+  delete-release-branch:
+    needs: [merge-into-main, merge-into-develop]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Delete release branch
+        run: git push origin --delete "${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,0 +1,46 @@
+name: "Start a release"
+
+concurrency: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: New version (x.y.z)
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  create-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Setup git name
+        run: |
+          git config --local user.name "kopfsachen-rna-bot"
+          git config --local user.email "<>"
+
+      - name: Create release branch
+        run: git switch -c "release/${{ github.event.inputs.version }}"
+
+      - name: Bump package.json version
+        run: |
+          # https://stackoverflow.com/a/60744617/5390250
+          cat <<< "$(jq '.version = "${{ github.event.inputs.version }}"' package.json)" > package.json
+          git add package.json
+          git commit -m "chore(release): bump version to ${{ github.event.inputs.version }}"
+
+      - name: Push
+        run: git push -u origin "release/${{ github.event.inputs.version }}"


### PR DESCRIPTION
https://nvie.com/posts/a-successful-git-branching-model/

Erweitert unsere Workflows um größtenteils automagische Releases.

* Bei Pushes auf main (die meistens in Form von Merges eines release-Branches stattfinden sollten) wird wie gewohnt gebaut und gepublished, jetzt aber auch ein Tag mit der Versionsnummer aus der package.json und ein Release erstellt. Aus dem Release lassen sich direkt die APK und iOS-App herunterladen
* Bei Pushes auf release/x.y.z wird in den Release-Channel rc-x.y.z gepublished
* Zwei neue Workflows sollen das Einhalten von Git Flow erleichtern:
  * release-start übernimmt das Erstellen eines Release-Branches und das setzen der Versionsnummer in der package.json
  * release-finish übernimmt das Mergen eines Release-Branches in main und develop (ersteres triggert das eigentliche Release, s.o.), und das Löschen des Release-Branches.

Leider war für die letzteren beiden workflows nötig, GITHUB_TOKEN durch eine App zu ersetzen, da Pushes mit dem GITHUB_TOKEN keine anderen Workflows triggern können, das hier aber nötig ist.

Closes #26